### PR TITLE
Ensure valid json with double-quotes is returned

### DIFF
--- a/tap_kit/executor.py
+++ b/tap_kit/executor.py
@@ -221,4 +221,4 @@ class TapExecutor:
             stream().generate_catalog() for stream in self.streams
         ]
 
-        return json.dump({'streams': catalog}, sys.stdout, indent=4)
+        return json.dump({"streams": catalog}, sys.stdout)


### PR DESCRIPTION
Tap kit is currently returning single quotes which is invalid in json schema

Indenting also seems to break the parsing