### PR TITLE
Dt 142 handle non utf 8 char in load ref tables gracefully

### DIFF
--- a/tap_kit/streams.py
+++ b/tap_kit/streams.py
@@ -116,6 +116,10 @@ class Stream:
         with singer.Transformer() as tx:
             metadata = self.stream_metadata if self.catalog.metadata else {}
 
+            for key in metadata.keys():
+                if b'\x00' in metadata[key]:
+                    metadata.update({metadata[key]: metadata[key].replace(b'\x00', '')})
+
             return tx.transform(
                 record,
                 self.catalog.schema.to_dict(),

--- a/tap_kit/streams.py
+++ b/tap_kit/streams.py
@@ -153,10 +153,7 @@ class Stream:
         self.update_start_date_bookmark()
         return self.get_bookmark()
 
-def validate_ingestible_data(record):
-    from pycore.text import to_unicode
-    import re
-    
+def validate_ingestible_data(record):    
     for key, value in record.items():
         if isinstance(value, dict):
             validate_ingestible_data(value)

--- a/tap_kit/streams.py
+++ b/tap_kit/streams.py
@@ -159,4 +159,3 @@ def validate_ingestible_data(record):
         else:
             if is_unicode(value):
                 record[key] = value.replace('\u0000', '') 
-    return record

--- a/tap_kit/streams.py
+++ b/tap_kit/streams.py
@@ -4,7 +4,6 @@ from .utils import safe_to_iso8601
 
 from pycore.text import to_unicode   
 
-
 _META_FIELDS = {
     'table-key-properties': 'key_properties',
     'replication-method': 'replication_method',
@@ -164,6 +163,5 @@ def validate_ingestible_data(record):
                 record[key] = ''
                 pass
             if len(str(value)) != len(str(value).encode()):
-                record[key] = value.encode("ascii", "ignore").replace(b'\x00', b'').decode()
-    
+                record[key] = value.replace('\u0000', '') 
     return record

--- a/tap_kit/streams.py
+++ b/tap_kit/streams.py
@@ -2,7 +2,7 @@ import singer
 
 from .utils import safe_to_iso8601
 
-from pycore.text import to_unicode   
+from pycore.text import is_unicode   
 
 _META_FIELDS = {
     'table-key-properties': 'key_properties',
@@ -157,11 +157,6 @@ def validate_ingestible_data(record):
         if isinstance(value, dict):
             validate_ingestible_data(value)
         else:
-            try:
-                record[key] = to_unicode(value)
-            except UnicodeDecodeError as e:
-                record[key] = ''
-                pass
-            if len(str(value)) != len(str(value).encode()):
+            if is_unicode(value):
                 record[key] = value.replace('\u0000', '') 
     return record


### PR DESCRIPTION
- Created function in tap-kit streams `validate_ingestible_data` and updated `transform_record` to run said function on each record to clean up non-ascii data and remove NUL bytes

https://simondata.atlassian.net/browse/DT-142

### **Testing**### 
I’ve completed the following unit tests:
1.  checking 1 issue record to make sure it remedied it
2. checking 2 correct correct to make sure it’s still correct
4. running an entire file through and spot checking issue records and correct records

And I've also tested it on a local tap:
I imported my entire TapKit into a Salesforce's tap and used that relative tap to run things with no errors (I ran `tap-salesforce -c config.json --discover > catalog.json` and then `tap-salesforce -c config.json -p catalog.json > results.txt`).


### **Risk** ### 
Need senior engineer review as it effects all records running through Tap-Kit